### PR TITLE
Combine `cd` && `sh` in (generated) Makefile

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,7 +7,7 @@ create_makefile 'rutgem'
 mkf = %(
 .ONESHELL:
 all:
-	cd case_transform
+	cd case_transform && \
 	sh ./build.sh
 
 clean:


### PR DESCRIPTION
Installing this gem failed with the message:

  ```
  creating Makefile

  make "DESTDIR=" clean
  rm -rf ./case_transform/target

  make "DESTDIR="
  cd case_transform
  sh ./build.sh
  sh: ./build.sh: No such file or directory
  make: *** [all] Error 127

  make failed, exit code 2
  ```

According to
https://stackoverflow.com/questions/19985936/current-working-directory-of-makefile#answer-19986164

> Each command is executed in its own shell, so "cd" only happens within
> that shell, but subsequent command is run again from make's current
> directory.